### PR TITLE
Feature/search container and modes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const App = () => {
   const viewer = useRef(null);
   const scrollView = useRef(null);
   const searchTerm = useRef(null);
+  const searchContainerRef = useRef(null);
 
   const [docViewer, setDocViewer] = useState(null);
   const [annotManager, setAnnotManager] = useState(null);
@@ -54,6 +55,46 @@ const App = () => {
       docViewer.setActiveSearchResult(searchResults[activeResultIndex]);
     }
   }, [ activeResultIndex ]);
+
+  useEffect(() => {
+    /**
+     * @todo Add the correct `style` mutations so that `SearchContainer`
+     * renders to the right of the `div#scroll-view` element
+     */
+    /*
+    if (searchContainerOpen) {
+      Object.assign(
+        scrollView.current.style,
+        {
+          width: '80%',
+        },
+      );
+      if (searchContainerRef && searchContainerRef.current) {
+        Object.assign(
+          searchContainerRef.current.style,
+          {
+            width: '20%',
+          },
+        );
+      }
+    } else {
+      Object.assign(
+        scrollView.current.style,
+        {
+          width: '100%',
+        },
+      );
+      if (searchContainerRef && searchContainerRef.current) {
+        Object.assign(
+          searchContainerRef.current.style,
+          {
+            width: '0%',
+          },
+        );
+      }
+    }
+    */
+  }, [ searchContainerOpen ])
 
   const zoomOut = () => {
     docViewer.zoomTo(docViewer.getZoom() - 0.25);
@@ -252,6 +293,7 @@ const App = () => {
         </button>
       </div>
       <SearchContainer
+        searchContainerRef={searchContainerRef}
         open={searchContainerOpen}
       />
       <div id="scroll-view" ref={scrollView}>

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import ZoomOut from './assets/icons/ic_zoom_out_black_24px.svg'
 import AnnotationRectangle from './assets/icons/ic_annotation_rectangular_area_black_24px.svg'
 import AnnotationRedact from './assets/icons/ic_annotation_add_redact_black_24px.svg'
 import AnnotationApplyRedact from './assets/icons/ic_annotation_apply_redact_black_24px.svg'
+import Search from './assets/icons/ic_search_black_24px.svg'
 import Select from './assets/icons/ic_select_black_24px.svg'
 import './App.css';
 
@@ -132,7 +133,7 @@ const App = () => {
             }
           }
         >
-          Open
+          <img src={Search} alt="Search"/>
         </button>
       </div>
       <SearchContainer

--- a/src/App.js
+++ b/src/App.js
@@ -5,11 +5,7 @@ import ZoomOut from './assets/icons/ic_zoom_out_black_24px.svg'
 import AnnotationRectangle from './assets/icons/ic_annotation_rectangular_area_black_24px.svg'
 import AnnotationRedact from './assets/icons/ic_annotation_add_redact_black_24px.svg'
 import AnnotationApplyRedact from './assets/icons/ic_annotation_apply_redact_black_24px.svg'
-import ClearSearch from './assets/icons/ic_close_black_24px.svg'
-import LeftChevronArrow from './assets/icons/ic_chevron_left_black_24px.svg'
-import RightChevronArrow from './assets/icons/ic_chevron_right_black_24px.svg'
 import Select from './assets/icons/ic_select_black_24px.svg'
-import Search from './assets/icons/ic_search_black_24px.svg'
 import './App.css';
 
 const App = () => {
@@ -20,8 +16,6 @@ const App = () => {
 
   const [docViewer, setDocViewer] = useState(null);
   const [annotManager, setAnnotManager] = useState(null);
-  const [searchResults, setSearchResults] = useState([]);
-  const [activeResultIndex, setActiveResultIndex] = useState(-1);
   const [searchContainerOpen, setSearchContainerOpen] = useState(false);
 
   const Annotations = window.Annotations;
@@ -46,15 +40,6 @@ const App = () => {
       setAnnotManager(docViewer.getAnnotationManager());
     });
   }, []);
-
-  /**
-   * Coupled with the function `changeActiveSearchResult`
-   */
-  useEffect(() => {
-    if (activeResultIndex && activeResultIndex >= 0) {
-      docViewer.setActiveSearchResult(searchResults[activeResultIndex]);
-    }
-  }, [ activeResultIndex ]);
 
   useEffect(() => {
     /**
@@ -122,124 +107,6 @@ const App = () => {
     await annotManager.applyRedactions();
   };
 
-  const performSearch = () => {
-    const {
-      current: {
-        value: textToSearch
-      }
-    } = searchTerm;
-    const {
-      SearchMode: {
-        e_page_stop: ePageStop,
-        e_highlight: eHighlight,
-      },
-    } = docViewer;
-    const mode = ePageStop | eHighlight;
-    const fullSearch = true;
-    let jumped = false;
-    docViewer.textSearchInit(textToSearch, mode, {
-      fullSearch,
-      onResult: result => {
-        setSearchResults(prevState => [...prevState, result]);
-        const {
-          resultCode,
-          quads,
-          // The page number in the callback parameter is 0-indexed
-          page_num: zeroIndexedPageNum,
-        } = result;
-        const {
-          e_found: eFound,
-        } = window.PDFNet.TextSearch.ResultCode
-        const pageNumber = zeroIndexedPageNum + 1;
-        if (resultCode === eFound) {
-          const highlight = new Annotations.TextHighlightAnnotation();
-          /**
-           * The page number in Annotations.TextHighlightAnnotation is not
-           * 0-indexed
-           */
-          highlight.setPageNumber(pageNumber);
-          highlight.Quads.push(quads[0].getPoints());
-          annotManager.addAnnotation(highlight);
-          annotManager.drawAnnotations(highlight.PageNumber);
-          if (!jumped) {
-            jumped = true;
-            // This is the first result found, so set `activeResult` accordingly
-            setActiveResultIndex(0);
-            docViewer.displaySearchResult(result, () => {
-              /**
-               * The page number in docViewer.displayPageLocation is not
-               * 0-indexed
-               */
-              docViewer.displayPageLocation(pageNumber, 0, 0, true);
-            });
-          }
-        }
-      }
-    });
-  };
-
-  /**
-   * Side-effect function that invokes the internal functions to clear the
-   * search results
-   */
-  const clearSearchResults = () => {
-    searchTerm.current.value = '';
-    docViewer.clearSearchResults();
-    annotManager.deleteAnnotations(annotManager.getAnnotationsList());
-    setSearchResults([]);
-    setActiveResultIndex(-1);
-  };
-
-  /**
-   * Checks if the key that has been released was the `Enter` key, and invokes
-   * `performSearch` if so
-   *
-   * @param {SyntheticEvent} event The event passed from the `input` element
-   * upon the function being invoked from a listener attribute, such as
-   * `onKeyUp`
-   */
-  const listenForEnter = (event) => {
-    const {
-      keyCode,
-    } = event;
-    // The key code for the enter button
-    if (keyCode === 13) {
-      // Cancel the default action, if needed
-      event.preventDefault();
-      // Trigger the button element with a click
-      performSearch();
-    }
-  };
-
-  /**
-   * Changes the active search result in `docViewer`
-   *
-   * @param {Number} newSearchResult The index to set `activeResult` to,
-   * indicating which `result` object that should be passed to
-   * `docViewer.setActiveSearchResult`
-   */
-  const changeActiveSearchResult = (newSearchResult) => {
-    /**
-     * @todo Figure out why only the middle set of search results can be
-     * iterated through, but not the first or last results.
-     */
-    /**
-     * Do not try to set a search result that is outside of the index range of
-     * searchResults
-     */
-    if (newSearchResult >= 0 && newSearchResult < searchResults.length) {
-      setActiveResultIndex(newSearchResult);
-    }
-  };
-
-  const prevSearchResult = () => {
-    changeActiveSearchResult(activeResultIndex - 1);
-  }
-
-  const nextSearchResult = () => {
-    changeActiveSearchResult(activeResultIndex + 1);
-  }
-
   return (
     <div className="App">
       <div>
@@ -257,30 +124,6 @@ const App = () => {
         <button onClick={selectTool}>
           <img src={Select} alt="Select"/>
         </button>
-        <input
-          ref={searchTerm}
-          type={'text'}
-          placeholder={'Search'}
-          onKeyUp={listenForEnter}
-        ></input>
-        <button onClick={performSearch}>
-          <img src={Search} alt="Search"/>
-        </button>
-        <button
-          onClick={prevSearchResult}
-          disabled={activeResultIndex < 0}
-        >
-          <img src={LeftChevronArrow} alt="Previous Search Result"/>
-        </button>
-        <button
-          onClick={nextSearchResult}
-          disabled={activeResultIndex < 0}
-        >
-          <img src={RightChevronArrow} alt="Next Search Result"/>
-        </button>
-        <button onClick={clearSearchResults}>
-          <img src={ClearSearch} alt="Clear Search"/>
-        </button>
         <button
           onClick={
             () => {
@@ -293,6 +136,10 @@ const App = () => {
         </button>
       </div>
       <SearchContainer
+        Annotations={Annotations}
+        annotManager={annotManager}
+        docViewer={docViewer}
+        searchTermRef={searchTerm}
         searchContainerRef={searchContainerRef}
         open={searchContainerOpen}
       />

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
+import SearchContainer from './components/SearchContainer';
 import ZoomIn from './assets/icons/ic_zoom_in_black_24px.svg'
 import ZoomOut from './assets/icons/ic_zoom_out_black_24px.svg'
 import AnnotationRectangle from './assets/icons/ic_annotation_rectangular_area_black_24px.svg'
@@ -20,6 +21,7 @@ const App = () => {
   const [annotManager, setAnnotManager] = useState(null);
   const [searchResults, setSearchResults] = useState([]);
   const [activeResultIndex, setActiveResultIndex] = useState(-1);
+  const [searchContainerOpen, setSearchContainerOpen] = useState(false);
 
   const Annotations = window.Annotations;
 
@@ -238,7 +240,20 @@ const App = () => {
         <button onClick={clearSearchResults}>
           <img src={ClearSearch} alt="Clear Search"/>
         </button>
+        <button
+          onClick={
+            () => {
+              // Flip the boolean
+              setSearchContainerOpen(prevState => !prevState);
+            }
+          }
+        >
+          Open
+        </button>
       </div>
+      <SearchContainer
+        open={searchContainerOpen}
+      />
       <div id="scroll-view" ref={scrollView}>
         <div id="viewer" ref={viewer}></div>
       </div>

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -27,6 +27,7 @@ const SearchContainer = (props) => {
   }, [ activeResultIndex ]);
 
   const performSearch = () => {
+    clearSearchResults(false);
     const {
       current: {
         value: textToSearch
@@ -85,9 +86,16 @@ const SearchContainer = (props) => {
   /**
    * Side-effect function that invokes the internal functions to clear the
    * search results
+   *
+   * @param {Boolean} clearSearchTermValue For the guard clause to determine
+   * if `searchTerm.current.value` should be mutated (would not want this to
+   * occur in the case where a subsequent search is being performed after a
+   * previous search)
    */
-  const clearSearchResults = () => {
-    searchTerm.current.value = '';
+  const clearSearchResults = (clearSearchTermValue = true) => {
+    if (clearSearchTermValue) {
+      searchTerm.current.value = '';
+    }
     docViewer.clearSearchResults();
     annotManager.deleteAnnotations(annotManager.getAnnotationsList());
     setSearchResults([]);

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -171,14 +171,6 @@ const SearchContainer = (props) => {
     }
   };
 
-  const prevSearchResult = () => {
-    changeActiveSearchResult(activeResultIndex - 1);
-  }
-
-  const nextSearchResult = () => {
-    changeActiveSearchResult(activeResultIndex + 1);
-  }
-
   /**
    * Toggles the given `searchMode` value within `toggledSearchModes`
    *
@@ -235,13 +227,13 @@ const SearchContainer = (props) => {
         <img src={Search} alt="Search"/>
       </button>
       <button
-        onClick={prevSearchResult}
+        onClick={() => { changeActiveSearchResult(activeResultIndex - 1); }}
         disabled={activeResultIndex < 0}
       >
         <img src={LeftChevronArrow} alt="Previous Search Result"/>
       </button>
       <button
-        onClick={nextSearchResult}
+        onClick={() => { changeActiveSearchResult(activeResultIndex + 1); }}
         disabled={activeResultIndex < 0}
       >
         <img src={RightChevronArrow} alt="Next Search Result"/>

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -42,7 +42,7 @@ const SearchContainer = (props) => {
    * Coupled with the function `changeActiveSearchResult`
    */
   useEffect(() => {
-    if (activeResultIndex && activeResultIndex >= 0) {
+    if (activeResultIndex >= 0 && activeResultIndex < searchResults.length) {
       docViewer.setActiveSearchResult(searchResults[activeResultIndex]);
     }
   }, [ activeResultIndex ]);

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -1,6 +1,14 @@
 import React from 'react';
 
-const SearchContainer = () => {
+const SearchContainer = (props) => {
+  const {
+    open = false,
+  } = props;
+
+  if (!open) {
+    return (null);
+  }
+
   return (
     <div>Hello World</div>
   );

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -1,10 +1,148 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import ClearSearch from '../../assets/icons/ic_close_black_24px.svg'
+import LeftChevronArrow from '../../assets/icons/ic_chevron_left_black_24px.svg'
+import RightChevronArrow from '../../assets/icons/ic_chevron_right_black_24px.svg'
+import Search from '../../assets/icons/ic_search_black_24px.svg'
 
 const SearchContainer = (props) => {
+  const [searchResults, setSearchResults] = useState([]);
+  const [activeResultIndex, setActiveResultIndex] = useState(-1);
+
   const {
+    Annotations,
+    annotManager,
+    docViewer,
     open = false,
     searchContainerRef,
+    searchTermRef: searchTerm,
   } = props;
+
+  /**
+   * Coupled with the function `changeActiveSearchResult`
+   */
+  useEffect(() => {
+    if (activeResultIndex && activeResultIndex >= 0) {
+      docViewer.setActiveSearchResult(searchResults[activeResultIndex]);
+    }
+  }, [ activeResultIndex ]);
+
+  const performSearch = () => {
+    const {
+      current: {
+        value: textToSearch
+      }
+    } = searchTerm;
+    const {
+      SearchMode: {
+        e_page_stop: ePageStop,
+        e_highlight: eHighlight,
+      },
+    } = docViewer;
+    const mode = ePageStop | eHighlight;
+    const fullSearch = true;
+    let jumped = false;
+    docViewer.textSearchInit(textToSearch, mode, {
+      fullSearch,
+      onResult: result => {
+        setSearchResults(prevState => [...prevState, result]);
+        const {
+          resultCode,
+          quads,
+          // The page number in the callback parameter is 0-indexed
+          page_num: zeroIndexedPageNum,
+        } = result;
+        const {
+          e_found: eFound,
+        } = window.PDFNet.TextSearch.ResultCode
+        const pageNumber = zeroIndexedPageNum + 1;
+        if (resultCode === eFound) {
+          const highlight = new Annotations.TextHighlightAnnotation();
+          /**
+           * The page number in Annotations.TextHighlightAnnotation is not
+           * 0-indexed
+           */
+          highlight.setPageNumber(pageNumber);
+          highlight.Quads.push(quads[0].getPoints());
+          annotManager.addAnnotation(highlight);
+          annotManager.drawAnnotations(highlight.PageNumber);
+          if (!jumped) {
+            jumped = true;
+            // This is the first result found, so set `activeResult` accordingly
+            setActiveResultIndex(0);
+            docViewer.displaySearchResult(result, () => {
+              /**
+               * The page number in docViewer.displayPageLocation is not
+               * 0-indexed
+               */
+              docViewer.displayPageLocation(pageNumber, 0, 0, true);
+            });
+          }
+        }
+      }
+    });
+  };
+
+  /**
+   * Side-effect function that invokes the internal functions to clear the
+   * search results
+   */
+  const clearSearchResults = () => {
+    searchTerm.current.value = '';
+    docViewer.clearSearchResults();
+    annotManager.deleteAnnotations(annotManager.getAnnotationsList());
+    setSearchResults([]);
+    setActiveResultIndex(-1);
+  };
+
+  /**
+   * Checks if the key that has been released was the `Enter` key, and invokes
+   * `performSearch` if so
+   *
+   * @param {SyntheticEvent} event The event passed from the `input` element
+   * upon the function being invoked from a listener attribute, such as
+   * `onKeyUp`
+   */
+  const listenForEnter = (event) => {
+    const {
+      keyCode,
+    } = event;
+    // The key code for the enter button
+    if (keyCode === 13) {
+      // Cancel the default action, if needed
+      event.preventDefault();
+      // Trigger the button element with a click
+      performSearch();
+    }
+  };
+
+  /**
+   * Changes the active search result in `docViewer`
+   *
+   * @param {Number} newSearchResult The index to set `activeResult` to,
+   * indicating which `result` object that should be passed to
+   * `docViewer.setActiveSearchResult`
+   */
+  const changeActiveSearchResult = (newSearchResult) => {
+    /**
+     * @todo Figure out why only the middle set of search results can be
+     * iterated through, but not the first or last results.
+     */
+    /**
+     * Do not try to set a search result that is outside of the index range of
+     * searchResults
+     */
+    if (newSearchResult >= 0 && newSearchResult < searchResults.length) {
+      setActiveResultIndex(newSearchResult);
+    }
+  };
+
+  const prevSearchResult = () => {
+    changeActiveSearchResult(activeResultIndex - 1);
+  }
+
+  const nextSearchResult = () => {
+    changeActiveSearchResult(activeResultIndex + 1);
+  }
 
   if (!open) {
     return (null);
@@ -14,7 +152,30 @@ const SearchContainer = (props) => {
     <div
       ref={searchContainerRef}
     >
-      Hello World
+      <input
+        ref={searchTerm}
+        type={'text'}
+        placeholder={'Search'}
+        onKeyUp={listenForEnter}
+      ></input>
+      <button onClick={performSearch}>
+        <img src={Search} alt="Search"/>
+      </button>
+      <button
+        onClick={prevSearchResult}
+        disabled={activeResultIndex < 0}
+      >
+        <img src={LeftChevronArrow} alt="Previous Search Result"/>
+      </button>
+      <button
+        onClick={nextSearchResult}
+        disabled={activeResultIndex < 0}
+      >
+        <img src={RightChevronArrow} alt="Next Search Result"/>
+      </button>
+      <button onClick={clearSearchResults}>
+        <img src={ClearSearch} alt="Clear Search"/>
+      </button>
     </div>
   );
 };

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const SearchContainer = () => {
+  return (
+    <div>Hello World</div>
+  );
+};
+
+export default SearchContainer;

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -225,7 +225,7 @@ const SearchContainer = (props) => {
         type={'text'}
         placeholder={'Search'}
         onKeyUp={listenForEnter}
-      ></input>
+      />
       <button onClick={performSearch}>
         <img src={Search} alt="Search"/>
       </button>

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -3,6 +3,7 @@ import React from 'react';
 const SearchContainer = (props) => {
   const {
     open = false,
+    searchContainerRef,
   } = props;
 
   if (!open) {
@@ -10,7 +11,11 @@ const SearchContainer = (props) => {
   }
 
   return (
-    <div>Hello World</div>
+    <div
+      ref={searchContainerRef}
+    >
+      Hello World
+    </div>
   );
 };
 

--- a/src/components/SearchContainer/SearchContainer.js
+++ b/src/components/SearchContainer/SearchContainer.js
@@ -47,6 +47,11 @@ const SearchContainer = (props) => {
     }
   }, [ activeResultIndex ]);
 
+  /**
+   * Side-effect function that invokes `docViewer.textSearchInit`, and stores
+   * every result in the state Array `searchResults`, and jumps the user to the
+   * first result is found.
+   */
   const performSearch = () => {
     clearSearchResults(false);
     const {

--- a/src/components/SearchContainer/index.js
+++ b/src/components/SearchContainer/index.js
@@ -1,0 +1,3 @@
+import SearchContainer from './SearchContainer';
+
+export default SearchContainer;


### PR DESCRIPTION
## Note

This PR temporarily merges to `feature/text-search` to keep the diff managable. I will target `master` when `feature/text-search` is merged, per this pending PR: https://github.com/PDFTron/webviewer-custom-ui/pull/2

## Preamble

This PR concerns moving all the search related logic and interface elements into a `SearchContainer` component to ensure we follow the [Separation of Concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) design pattern.

This PR also adds functionality to allow the user to toggle `Case sensitive` and `Whole word` searching modes.

![search-prev-next](https://user-images.githubusercontent.com/16601729/85079986-ef798100-b17c-11ea-9f97-e490db9760ed.gif)
